### PR TITLE
Add TYPE setting for support of most particles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.benzoft</groupId>
     <artifactId>gravitytubes</artifactId>
-    <version>1.10.6</version>
+    <version>1.11.0</version>
     <packaging>jar</packaging>
 
     <name>GravityTubes</name>

--- a/src/main/java/com/benzoft/gravitytubes/GravityTube.java
+++ b/src/main/java/com/benzoft/gravitytubes/GravityTube.java
@@ -1,17 +1,20 @@
 package com.benzoft.gravitytubes;
 
-import com.benzoft.gravitytubes.utils.LocationUtil;
-import com.benzoft.gravitytubes.utils.ParticleUtil;
-import lombok.Getter;
-import org.bukkit.Location;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.Entity;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Entity;
+
+import com.benzoft.gravitytubes.utils.LocationUtil;
+import com.benzoft.gravitytubes.utils.ParticleUtil;
+
+import lombok.Getter;
 
 public class GravityTube {
 
@@ -25,7 +28,8 @@ public class GravityTube {
     @Getter
     private int power;
     private ParticleUtil.GTParticleColor color;
-
+    @Getter
+    private Particle type;
 
     public GravityTube(final Location sourceLocation, final ConfigurationSection configurationSection) {
         this.sourceLocation = sourceLocation;
@@ -33,7 +37,7 @@ public class GravityTube {
         height = configurationSection.getInt("height", 256 - sourceLocation.getBlockY());
         power = configurationSection.getInt("power", 10);
         color = ParticleUtil.getFromColor(configurationSection.getString("color", "white"));
-        color = color == null ? ParticleUtil.GTParticleColor.WHITE : color;
+        type = Particle.valueOf(configurationSection.getString("type", "spell_mob").toUpperCase());
         owners = configurationSection.getStringList("owners");
     }
 
@@ -50,7 +54,7 @@ public class GravityTube {
             xOffset = ThreadLocalRandom.current().nextDouble(1);
             zOffset = ThreadLocalRandom.current().nextDouble(1);
             if (ThreadLocalRandom.current().nextDouble(1) >= 0.2) //TODO Particle density setting.
-                ParticleUtil.spawnParticle(new Location(sourceLocation.getWorld(), sourceLocation.getBlockX() + xOffset, y, sourceLocation.getBlockZ() + zOffset), color);
+                ParticleUtil.spawnParticle(type, new Location(sourceLocation.getWorld(), sourceLocation.getBlockX() + xOffset, y, sourceLocation.getBlockZ() + zOffset), color);
         }
     }
 
@@ -71,6 +75,11 @@ public class GravityTube {
     public void setColor(final String color) {
         this.color = ParticleUtil.getFromColor(color);
         configurationSection.set("color", color);
+    }
+    
+    public void setType(final Particle type) {
+        this.type = type;
+        configurationSection.set("type", type.name());
     }
 
     public String getInfo() {

--- a/src/main/java/com/benzoft/gravitytubes/GravityTube.java
+++ b/src/main/java/com/benzoft/gravitytubes/GravityTube.java
@@ -1,34 +1,31 @@
 package com.benzoft.gravitytubes;
 
+import com.benzoft.gravitytubes.utils.LocationUtil;
+import com.benzoft.gravitytubes.utils.ParticleUtil;
+import lombok.AccessLevel;
+import lombok.Getter;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Entity;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.bukkit.Location;
-import org.bukkit.Particle;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.Entity;
-
-import com.benzoft.gravitytubes.utils.LocationUtil;
-import com.benzoft.gravitytubes.utils.ParticleUtil;
-
-import lombok.Getter;
-
+@Getter
 public class GravityTube {
 
-    @Getter
     private final Location sourceLocation;
+    @Getter(AccessLevel.NONE)
     private final ConfigurationSection configurationSection;
-    @Getter
     private final List<String> owners;
-    @Getter
     private int height;
-    @Getter
     private int power;
+    @Getter(AccessLevel.NONE)
     private ParticleUtil.GTParticleColor color;
-    @Getter
     private Particle type;
 
     public GravityTube(final Location sourceLocation, final ConfigurationSection configurationSection) {
@@ -76,7 +73,7 @@ public class GravityTube {
         this.color = ParticleUtil.getFromColor(color);
         configurationSection.set("color", color);
     }
-    
+
     public void setType(final Particle type) {
         this.type = type;
         configurationSection.set("type", type.name());
@@ -86,6 +83,7 @@ public class GravityTube {
         return Stream.of(
                 "&9&m&l---&e Gravity Tube Info &9&m&l--------",
                 " &7- &eLocation: &a" + LocationUtil.locationToString(sourceLocation),
+                " &7- &eParticle: &a" + type.name(),
                 " &7- &eHeight: &a" + height,
                 " &7- &ePower: &a" + power,
                 " &7- &eColor: &a" + color.getName(),

--- a/src/main/java/com/benzoft/gravitytubes/commands/gravitytubes/Settings.java
+++ b/src/main/java/com/benzoft/gravitytubes/commands/gravitytubes/Settings.java
@@ -1,5 +1,15 @@
 package com.benzoft.gravitytubes.commands.gravitytubes;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.bukkit.Particle;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+
 import com.benzoft.gravitytubes.GTPerm;
 import com.benzoft.gravitytubes.GravityTube;
 import com.benzoft.gravitytubes.commands.AbstractSubCommand;
@@ -7,15 +17,8 @@ import com.benzoft.gravitytubes.files.GravityTubesFile;
 import com.benzoft.gravitytubes.files.MessagesFile;
 import com.benzoft.gravitytubes.utils.MessageUtil;
 import com.benzoft.gravitytubes.utils.ParticleUtil;
-import lombok.Getter;
-import org.bukkit.entity.Player;
-import org.bukkit.permissions.PermissionAttachmentInfo;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import lombok.Getter;
 
 
 public class Settings extends AbstractSubCommand {
@@ -68,11 +71,25 @@ public class Settings extends AbstractSubCommand {
                         break;
                     case COLOR:
                         final ParticleUtil.GTParticleColor color = reset ? ParticleUtil.GTParticleColor.WHITE : ParticleUtil.getFromColor(args[2]);
-                        if (color != null) {
-                            targetTube.setColor(reset ? "white" : args[2]);
-                            success = true;
+                        if (ParticleUtil.isColorable(targetTube.getType())) {
+                            if (color != null) {
+                                targetTube.setColor(reset ? "white" : args[2]);
+                                success = true;
+                            }
+                        } else {
+                            MessageUtil.send(player, MessagesFile.getInstance().getSettingInvalid());
+                            return;
                         }
                         break; //TODO stop at top, particle density, pass through blocks.
+                    case TYPE:
+                        try {
+                            final Particle type = reset ? Particle.SPELL_MOB : Particle.valueOf(args[2].toUpperCase());
+                            if (type != null && ParticleUtil.isSupported(type)) {
+                                targetTube.setType(reset ? Particle.SPELL_MOB : Particle.valueOf(args[2].toUpperCase()));
+                                success = true;
+                            }
+                        } catch (final IllegalArgumentException ignored) {}
+                        break;
                 }
             }
             MessageUtil.send(player, success ? reset ? MessagesFile.getInstance().getSettingReset() : MessagesFile.getInstance().getSettingSet() : MessagesFile.getInstance().getInvalidArguments());
@@ -93,6 +110,8 @@ public class Settings extends AbstractSubCommand {
                         return args.length == 2 ? Collections.singletonList("10") : Collections.emptyList();
                     case COLOR:
                         return args.length == 2 ? Stream.of(ParticleUtil.GTParticleColor.values()).map(ParticleUtil.GTParticleColor::getName).filter(color -> color.toLowerCase().startsWith(args[1].toLowerCase())).collect(Collectors.toList()) : Collections.emptyList();
+                    case TYPE:
+                        return args.length == 2 ? Stream.of(Particle.values()).filter(value -> ParticleUtil.isSupported(value)).map(Particle::name).filter(type -> type.toLowerCase().startsWith(args[1].toLowerCase())).collect(Collectors.toList()) : Collections.emptyList();
                 }
             }
         }
@@ -102,7 +121,8 @@ public class Settings extends AbstractSubCommand {
     private enum Attribute {
         HEIGHT("height", "h"),
         POWER("power", "p"),
-        COLOR("color", "c");
+        COLOR("color", "c"),
+        TYPE("type", "t");
 
         @Getter
         private final String fullName;

--- a/src/main/java/com/benzoft/gravitytubes/commands/gravitytubes/Settings.java
+++ b/src/main/java/com/benzoft/gravitytubes/commands/gravitytubes/Settings.java
@@ -1,15 +1,5 @@
 package com.benzoft.gravitytubes.commands.gravitytubes;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.bukkit.Particle;
-import org.bukkit.entity.Player;
-import org.bukkit.permissions.PermissionAttachmentInfo;
-
 import com.benzoft.gravitytubes.GTPerm;
 import com.benzoft.gravitytubes.GravityTube;
 import com.benzoft.gravitytubes.commands.AbstractSubCommand;
@@ -17,8 +7,16 @@ import com.benzoft.gravitytubes.files.GravityTubesFile;
 import com.benzoft.gravitytubes.files.MessagesFile;
 import com.benzoft.gravitytubes.utils.MessageUtil;
 import com.benzoft.gravitytubes.utils.ParticleUtil;
-
 import lombok.Getter;
+import org.bukkit.Particle;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 public class Settings extends AbstractSubCommand {
@@ -47,7 +45,7 @@ public class Settings extends AbstractSubCommand {
                 switch (attribute) {
                     case HEIGHT:
                         try {
-                            final Integer permissibleHeight = player.getEffectivePermissions().stream()
+                            final int permissibleHeight = player.getEffectivePermissions().stream()
                                     .map(PermissionAttachmentInfo::getPermission)
                                     .filter(permission -> permission.startsWith(GTPerm.COMMANDS_SETTINGS.getPermissionString() + ".height."))
                                     .flatMap(permission -> {
@@ -84,9 +82,12 @@ public class Settings extends AbstractSubCommand {
                     case TYPE:
                         try {
                             final Particle type = reset ? Particle.SPELL_MOB : Particle.valueOf(args[2].toUpperCase());
-                            if (type != null && ParticleUtil.isSupported(type)) {
+                            if (ParticleUtil.isSupported(type)) {
                                 targetTube.setType(reset ? Particle.SPELL_MOB : Particle.valueOf(args[2].toUpperCase()));
                                 success = true;
+                            } else {
+                                MessageUtil.send(player, MessagesFile.getInstance().getSettingInvalid());
+                                return;
                             }
                         } catch (final IllegalArgumentException ignored) {}
                         break;
@@ -111,7 +112,7 @@ public class Settings extends AbstractSubCommand {
                     case COLOR:
                         return args.length == 2 ? Stream.of(ParticleUtil.GTParticleColor.values()).map(ParticleUtil.GTParticleColor::getName).filter(color -> color.toLowerCase().startsWith(args[1].toLowerCase())).collect(Collectors.toList()) : Collections.emptyList();
                     case TYPE:
-                        return args.length == 2 ? Stream.of(Particle.values()).filter(value -> ParticleUtil.isSupported(value)).map(Particle::name).filter(type -> type.toLowerCase().startsWith(args[1].toLowerCase())).collect(Collectors.toList()) : Collections.emptyList();
+                        return args.length == 2 ? Stream.of(Particle.values()).filter(ParticleUtil::isSupported).map(Particle::name).filter(type -> type.toLowerCase().startsWith(args[1].toLowerCase())).collect(Collectors.toList()) : Collections.emptyList();
                 }
             }
         }

--- a/src/main/java/com/benzoft/gravitytubes/files/GravityTubesFile.java
+++ b/src/main/java/com/benzoft/gravitytubes/files/GravityTubesFile.java
@@ -1,16 +1,18 @@
 package com.benzoft.gravitytubes.files;
 
 
-import com.benzoft.gravitytubes.GravityTube;
-import com.benzoft.gravitytubes.utils.LocationUtil;
-import lombok.Getter;
-import org.bukkit.Location;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import org.bukkit.Location;
+
+import com.benzoft.gravitytubes.GravityTube;
+import com.benzoft.gravitytubes.utils.LocationUtil;
+
+import lombok.Getter;
 
 public final class GravityTubesFile extends AbstractFile {
 
@@ -50,6 +52,7 @@ public final class GravityTubesFile extends AbstractFile {
         getConfig().set("GravityTubes." + locationsString + ".height", height);
         getConfig().set("GravityTubes." + locationsString + ".power", power);
         getConfig().set("GravityTubes." + locationsString + ".color", "white");
+        getConfig().set("GravityTubes." + locationsString + ".type", "spell_mob");
         save();
         tubes.stream().filter(tube -> tube.getSourceLocation().equals(location)).findFirst().ifPresent(tube -> tubes.remove(tube));
         tubes.add(new GravityTube(location, getConfig().getConfigurationSection("GravityTubes." + locationsString)));

--- a/src/main/java/com/benzoft/gravitytubes/files/MessagesFile.java
+++ b/src/main/java/com/benzoft/gravitytubes/files/MessagesFile.java
@@ -21,6 +21,7 @@ public final class MessagesFile extends AbstractFile {
     private String noTube;
     private String settingReset;
     private String settingSet;
+    private String settingInvalid;
     private String inCombat;
 
     //Admin
@@ -75,6 +76,7 @@ public final class MessagesFile extends AbstractFile {
         noTube = (String) add("Messages.GravityTubes.NoTube", "%prefix% &cNo gravity tube found at the targeted location!");
         settingReset = (String) add("Messages.GravityTubes.SettingReset", "%prefix% &aThe setting was set to the default!");
         settingSet = (String) add("Messages.GravityTubes.SettingSet", "%prefix% &aThe setting was successfully set to the specified value!");
+        settingInvalid = (String) add("Messages.GravityTubes.SettingInvalid", "%prefix% &cThe setting was not available for this tube!");
         inCombat = (String) add("Messages.GravityTubes.InCombat", "%prefix% &cYou can't use Gravity Tubes when in combat!");
 
         configReload = (String) add("Messages.Admin.ConfigurationsReloaded", "%prefix% &aConfiguration files successfully reloaded!");

--- a/src/main/java/com/benzoft/gravitytubes/utils/ParticleUtil.java
+++ b/src/main/java/com/benzoft/gravitytubes/utils/ParticleUtil.java
@@ -1,27 +1,19 @@
 package com.benzoft.gravitytubes.utils;
 
-import java.util.stream.Stream;
-
+import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 
-import lombok.Getter;
+import java.util.Arrays;
+import java.util.stream.Stream;
 
 public final class ParticleUtil {
 
     public static GTParticleColor getFromColor(final String color) {
         return Stream.of(GTParticleColor.values()).filter(gtParticleColor -> gtParticleColor.getColorCode().equalsIgnoreCase(color) || gtParticleColor.toString().equalsIgnoreCase(color)).findFirst().orElse(null);
     }
-    
-    /**
-     * @deprecated Use {@link #spawnParticle(Particle, Location, GTParticleColor)}
-     */
-    @Deprecated
-    public static void spawnParticle(final Location location, final GTParticleColor color) {
-        spawnParticle(Particle.SPELL_MOB, location, color);
-    }
-    
+
     public static void spawnParticle(final Particle type, final Location location, final GTParticleColor color) {
         if (!isSupported(type)) return;
         final float r = isColorable(type) ? color.getR() : 0;
@@ -29,32 +21,19 @@ public final class ParticleUtil {
         final float b = isColorable(type) ? color.getB() : 0;
         if (Stream.of("1.8", "1.9", "1.10", "1.11", "1.12").noneMatch(Bukkit.getVersion()::contains)) {
             if (type.getDataType().getSimpleName().equals("DustOptions")) {
-                location.getWorld().spawnParticle(type, location, 0, 0, 0, 0, 1, 
-                        new Particle.DustOptions(org.bukkit.Color.fromRGB((int)(r*255.999), (int)(g*255.999), (int)(b*255.999)), 1));
-            } else location.getWorld().spawnParticle(type, location, 0, r, g, b, 10, null);
-        } else location.getWorld().getPlayers().stream().filter(player -> player.getLocation().distance(location) < 40)
-        .forEach(player -> player.spawnParticle(type, location, 0, r, g, b, 10, null));
+                location.getWorld().getPlayers().stream().filter(player -> player.getLocation().distance(location) < 40).forEach(player -> player.spawnParticle(type, location, 0, 0, 0, 0, 1, new Particle.DustOptions(org.bukkit.Color.fromRGB((int) (r * 255.999), (int) (g * 255.999), (int) (b * 255.999)), 1)));
+            } else
+                location.getWorld().getPlayers().stream().filter(player -> player.getLocation().distance(location) < 40).forEach(player -> player.spawnParticle(type, location, 0, r, g, b, 10, null));
+        } else
+            location.getWorld().spawnParticle(type, location, 0, r, g, b, 10, null);
     }
-    
+
     public static boolean isSupported(final Particle type) {
-        switch(type.getDataType().getSimpleName()) {
-        case "Void":
-        case "DustOptions":
-            return true;
-        default:
-            return false;
-        }
+        return Arrays.asList("Void", "DustOptions").contains(type.getDataType().getSimpleName());
     }
-    
+
     public static boolean isColorable(final Particle type) {
-        switch(type) {
-        case SPELL_MOB:
-        case SPELL_MOB_AMBIENT:
-        case REDSTONE:
-            return true;
-        default:
-            return false;
-        }
+        return Arrays.asList(Particle.SPELL_MOB, Particle.SPELL_MOB_AMBIENT, Particle.REDSTONE).contains(type);
     }
 
     @Getter

--- a/src/main/java/com/benzoft/gravitytubes/utils/ParticleUtil.java
+++ b/src/main/java/com/benzoft/gravitytubes/utils/ParticleUtil.java
@@ -1,22 +1,60 @@
 package com.benzoft.gravitytubes.utils;
 
-import lombok.Getter;
+import java.util.stream.Stream;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 
-import java.util.stream.Stream;
+import lombok.Getter;
 
 public final class ParticleUtil {
 
     public static GTParticleColor getFromColor(final String color) {
         return Stream.of(GTParticleColor.values()).filter(gtParticleColor -> gtParticleColor.getColorCode().equalsIgnoreCase(color) || gtParticleColor.toString().equalsIgnoreCase(color)).findFirst().orElse(null);
     }
-
+    
+    /**
+     * @deprecated Use {@link #spawnParticle(Particle, Location, GTParticleColor)}
+     */
+    @Deprecated
     public static void spawnParticle(final Location location, final GTParticleColor color) {
+        spawnParticle(Particle.SPELL_MOB, location, color);
+    }
+    
+    public static void spawnParticle(final Particle type, final Location location, final GTParticleColor color) {
+        if (!isSupported(type)) return;
+        final float r = isColorable(type) ? color.getR() : 0;
+        final float g = isColorable(type) ? color.getG() : 0;
+        final float b = isColorable(type) ? color.getB() : 0;
         if (Stream.of("1.8", "1.9", "1.10", "1.11", "1.12").noneMatch(Bukkit.getVersion()::contains)) {
-            location.getWorld().getPlayers().stream().filter(player -> player.getLocation().distance(location) < 40).forEach(player -> player.spawnParticle(Particle.SPELL_MOB, location, 0, color.getR(), color.getG(), color.getB(), 10, null));
-        } else location.getWorld().spawnParticle(Particle.SPELL_MOB, location, 0, color.getR(), color.getG(), color.getB(), 10, null);
+            if (type.getDataType().getSimpleName().equals("DustOptions")) {
+                location.getWorld().spawnParticle(type, location, 0, 0, 0, 0, 1, 
+                        new Particle.DustOptions(org.bukkit.Color.fromRGB((int)(r*255.999), (int)(g*255.999), (int)(b*255.999)), 1));
+            } else location.getWorld().spawnParticle(type, location, 0, r, g, b, 10, null);
+        } else location.getWorld().getPlayers().stream().filter(player -> player.getLocation().distance(location) < 40)
+        .forEach(player -> player.spawnParticle(type, location, 0, r, g, b, 10, null));
+    }
+    
+    public static boolean isSupported(final Particle type) {
+        switch(type.getDataType().getSimpleName()) {
+        case "Void":
+        case "DustOptions":
+            return true;
+        default:
+            return false;
+        }
+    }
+    
+    public static boolean isColorable(final Particle type) {
+        switch(type) {
+        case SPELL_MOB:
+        case SPELL_MOB_AMBIENT:
+        case REDSTONE:
+            return true;
+        default:
+            return false;
+        }
     }
 
     @Getter


### PR DESCRIPTION
Introduces _/gt settings type [value]_ for specifying the particle type. Includes tab complete, backwards-compatible utility methods and a new message for setting color on unsupported type. Tested working on MC 1.16 as shown below.

![2020-08-30_21 37 28](https://user-images.githubusercontent.com/2267126/91675109-2d920a00-eb09-11ea-8524-f595618d7bbc.png)

On a related note, I've created a dummy repository so as to compile GravityTubes without owning Spartan. Feel free to fork and depend on it should you so desire: https://github.com/PikaMug/SpartanAPI-Dummy